### PR TITLE
Add entry point for local Mistral CrewAI agents

### DIFF
--- a/mistral-agents.py
+++ b/mistral-agents.py
@@ -1,16 +1,15 @@
-from crewai import Agent, Task, Crew
+from crewai import Agent, Task, Crew, Process
 from langchain_openai import ChatOpenAI
 import os
 
 
-
-os.environ["OPENAI_API_KEY"] = "NA"
-
+# Retrieve the API key from the environment and configure the local model
+api_key = os.getenv("OPENAI_API_KEY")
 llm = ChatOpenAI(
-
-    model = "mistralcrew",
-
-    base_url = "http://localhost:11434/v1")
+    model="mistralcrew",
+    base_url="http://localhost:11434/v1",
+    api_key=api_key,
+)
 
 
 #agent1 researcher
@@ -61,10 +60,10 @@ task2 = Task(
 crew = Crew(
   agents=[researcher, writer],
   tasks=[task1, task2],
-  verbose=2, 
+  process=Process.sequential,
+  verbose=2,
 )
 
-
-result = crew.kickoff()
-
-print(result)
+if __name__ == "__main__":
+    result = crew.kickoff()
+    print(result)


### PR DESCRIPTION
## Summary
- Configure CrewAI `researcher` and `writer` agents to use a local Mistral model
- Read OpenAI API key from environment variables and run agents sequentially

## Testing
- `python mistral-agents.py` *(fails: ModuleNotFoundError: No module named 'crewai')*
- `pip install langchain-openai` *(fails: Could not find a version that satisfies the requirement langchain-openai)*
- `pip install crewai` *(fails: Could not find a version that satisfies the requirement crewai)*

------
https://chatgpt.com/codex/tasks/task_e_68af77e22c808326b1eda73b1a7e252b