### PR TITLE
Use environment variable for API key and document .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@ This repository is an example of a local setup for using agentic workflow using 
 
 
 ## Running The Agents
-This project uses a free API formality key from OpenAI, but you can replace it with your paid API key from other providers.
+This project uses an OpenAI-compatible API key. Store the key in a `.env` file or as an environment variable.
 
 1. Set up a virtual environment using the `pyvenv.cfg` setting.
-2. Configure your environment using the `dotenv` or `.env` file in your bin directory with Ollama endpoints and your choice of the large language model.
+2. Create a `.env` file in this directory and define `OPENAI_API_KEY` along with any other settings like the Ollama endpoint. Optionally install `python-dotenv` so the agents can read the `.env` file automatically.
+
+```
+OPENAI_API_KEY=your_key_here
+```
 3. Create a Model File to specify the base LLM and set the PARAMETERs and the SYSTEM message to shape the behaviour of the LLM.
 4. Create a shell file to pull the information from the Model File and then execute it via your terminal.
 5. Make the necessary changes to the Python file based on your project goals, then run it.

--- a/mistral-agents.py
+++ b/mistral-agents.py
@@ -1,9 +1,13 @@
 from crewai import Agent, Task, Crew, Process
 from langchain_openai import ChatOpenAI
 import os
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
 
-
-# Retrieve the API key from the environment and configure the local model
+# Optionally load environment variables from a .env file and configure the local model
 api_key = os.getenv("OPENAI_API_KEY")
 llm = ChatOpenAI(
     model="mistralcrew",


### PR DESCRIPTION
## Summary
- load OPENAI_API_KEY from environment and optionally from `.env`
- add documentation for `.env` setup with example

## Testing
- `python -m py_compile mistral-agents.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af7abdc3bc8326ac6bf1ea05747410